### PR TITLE
postfix - branch+commit_id, use params.sh in prepare-cf

### DIFF
--- a/.github/actions/cleanup-cf/entrypoint.sh
+++ b/.github/actions/cleanup-cf/entrypoint.sh
@@ -5,11 +5,11 @@ source ".github/base-dockerfile/helpers/cf-helper.sh"
 source ".github/base-dockerfile/helpers/params.sh"
 
 echo "CleanUP: delete service broker, service, unbind app"
-INSTALL_TIMEOUT=40 #service deploy timeout
+INSTALL_TIMEOUT=30 #service deploy timeout
 
 make_pcf_metadata $INPUT_PCF_URL $INPUT_PCF_USER $INPUT_PCF_PASSWORD
 
-cf_login $ORG_NAME $ORG_NAME
+cf_login $ORG_NAME $SPACE_NAME
 
 delete_service_app_if_exists $SERVICE_ATLAS $TEST_SIMPLE_APP
 cf delete-service-broker $BROKER -f
@@ -17,3 +17,4 @@ delete_application $TEST_SPRING_APP
 delete_application $TEST_SIMPLE_APP
 delete_application $BROKER_APP
 cf delete-service $CREDHUB -f
+cf delete-space $SPACE_NAME -f

--- a/.github/actions/prepare-cf/entrypoint.sh
+++ b/.github/actions/prepare-cf/entrypoint.sh
@@ -2,35 +2,35 @@
 
 source ".github/base-dockerfile/helpers/tmp-helper.sh"
 source ".github/base-dockerfile/helpers/cf-helper.sh"
+source ".github/base-dockerfile/helpers/params.sh"
 
 echo "Prepare CF env for testing"
 
 echo "init"
 INSTALL_TIMEOUT=40 #service deploy timeout
 branch_name=$(echo $GITHUB_REF | awk -F'/' '{print $3}')
-org_name="atlas-test-$branch_name"
 make_pcf_metadata $INPUT_PCF_URL $INPUT_PCF_USER $INPUT_PCF_PASSWORD
 
 echo "Login. Create ORG and SPACE depended on the branch name"
 cf_login
-cf create-org $org_name && cf target -o $org_name
-cf create-space $org_name && cf target -s $org_name
+cf create-org $ORG_NAME && cf target -o $ORG_NAME
+cf create-space $SPACE_NAME && cf target -s $SPACE_NAME
 
 echo "Create service-broker"
-create_atlas_service_broker_from_repo mongodb-atlas-$branch_name atlas-osb-app-$branch_name
+create_atlas_service_broker_from_repo $BROKER $BROKER_APP
 
 cf marketplace
 
-create_service aws-atlas-test-instance-$branch_name
+create_service $SERVICE_ATLAS "M10"
 
 echo "Simple app"
 git clone https://github.com/leo-ri/simple-ruby.git
 cd simple-ruby
-cf push simple-app-$branch_name --no-start
-cf bind-service simple-app-$branch_name aws-atlas-test-instance-$branch_name
-cf restart simple-app-$branch_name
-check_app_started simple-app-$branch_name
-app_url=$(cf app simple-app-$branch_name | awk '$1 ~ /routes:/{print $2}')
+cf push $TEST_SIMPLE_APP --no-start
+cf bind-service $TEST_SIMPLE_APP $SERVICE_ATLAS
+cf restart $TEST_SIMPLE_APP
+check_app_started $TEST_SIMPLE_APP
+app_url=$(cf app $TEST_SIMPLE_APP | awk '$1 ~ /routes:/{print $2}')
 echo "::set-output name=app_url::$app_url"
 
 #echo "Prepare app"

--- a/.github/actions/prepare-credhub/entrypoint.sh
+++ b/.github/actions/prepare-credhub/entrypoint.sh
@@ -16,7 +16,7 @@ make_sample_credhub_config ./credhub-config.json
 echo "Login. Create ORG and SPACE depended on the branch name"
 cf_login
 cf create-org $ORG_NAME && cf target -o $ORG_NAME
-cf create-space $ORG_NAME && cf target -s $ORG_NAME
+cf create-space $SPACE_NAME && cf target -s $SPACE_NAME
 
 echo "Create credhub service" #credhub broker already exist
 cf create-service credhub default $CREDHUB -c ./credhub-config.json

--- a/.github/base-dockerfile/helpers/params.sh
+++ b/.github/base-dockerfile/helpers/params.sh
@@ -1,9 +1,13 @@
 branch_name=$(echo $GITHUB_REF | awk -F'/' '{print $3}')
+commit_id=$(git rev-parse --short HEAD)
+postfix=$branch_name-$commit_id
+
 #arguments for actions
 ORG_NAME="atlas-test-$branch_name"
-BROKER=atlas-broker-$branch_name
-BROKER_APP=atlas-osb-app-$branch_name
-CREDHUB=credhub-$branch_name
-TEST_SIMPLE_APP=simple-app-$branch_name
-TEST_SPRING_APP=music-$branch_name
-SERVICE_ATLAS=aws-atlas-test-instance-$branch_name
+SPACE_NAME=$commit_id
+BROKER=atlas-broker-$postfix
+BROKER_APP=atlas-osb-app-$postfix
+CREDHUB=credhub-$postfix
+TEST_SIMPLE_APP=simple-app-$postfix
+TEST_SPRING_APP=music-$postfix
+SERVICE_ATLAS=aws-atlas-test-instance-$postfix

--- a/.github/workflows/deploy-broker.yml
+++ b/.github/workflows/deploy-broker.yml
@@ -13,13 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@master
       
-      - name: Cleanup ENV for current branch
-        uses: ./.github/actions/cleanup-cf
-        with:
-          pcf_url: ${{ secrets.PCF_URL }}
-          pcf_user: ${{ secrets.PCF_USER }}
-          pcf_password: ${{ secrets.PCF_PASSWORD }}
-
       - name: Create CF org, space, broker, service and push app)
         id: prepare
         uses: ./.github/actions/prepare-credhub
@@ -33,7 +26,7 @@ jobs:
           atlas_private_key: ${{ secrets.ATLAS_PRIVATE_KEY }}
           credhub_file: ${{ secrets.CREDHUB_FILE }}
 
-      - name: Check application. Add album
+      - name: Check application.
         id: check
         env:
           APP_URL: ${{ steps.prepare.outputs.app_url }}
@@ -65,3 +58,10 @@ jobs:
               echo "FAILED. Application doesn't work"
               exit 1
           fi
+
+      - name: Cleanup ENV for current branch
+        uses: ./.github/actions/cleanup-cf
+        with:
+          pcf_url: ${{ secrets.PCF_URL }}
+          pcf_user: ${{ secrets.PCF_USER }}
+          pcf_password: ${{ secrets.PCF_PASSWORD }}


### PR DESCRIPTION
next push can lead to failure if it is performed before finishing the previous action 

fix:
before: branch name is used as a postfix for all names (sb, services, app).
after: branch name+commit_id used as a postfix for all names(sb, services, app). space name is equal to commit id